### PR TITLE
Fix: links not being shared on Firefox mobile

### DIFF
--- a/share-button.js
+++ b/share-button.js
@@ -18,7 +18,8 @@ class ShareButton extends HTMLElement {
     window.navigator
       .share({
         title: root.title,
-        text: root.title + "\n" + window.location.href,
+        text: root.title,
+        url: window.location.href,
       })
       .then(() => console.log("Page was succesffuly shared"))
       .catch((error) => console.log(error));


### PR DESCRIPTION
Links not being shared from Firefox Mobile on Android.

Expected result (with this fix):

![Expected Screenshot of share in Gmail](https://github.com/daviddarnes/share-button/assets/37806009/9247b4db-71d2-46b5-93e3-a5c93d81335b)

Actual result:

![Actual Screenshot of share in Gmail](https://github.com/daviddarnes/share-button/assets/37806009/649b1846-870b-4bbb-a617-19c5cd6652f2)
